### PR TITLE
rails dup behaviour changed

### DIFF
--- a/lib/action_smser/base.rb
+++ b/lib/action_smser/base.rb
@@ -53,7 +53,11 @@ class ActionSmser::Base
 
   # Called from class.method_missing with own_sms_message when you call OwnMailer.own_sms_message
   def initialize(method_name = 'no_name_given', *args)
-    @delivery_options = ActionSmser.delivery_options.deep_dup
+    @delivery_options = {}
+    ActionSmser.delivery_options.each do |key,value|
+      value = value.dup if value.is_a?(Hash) || value.is_a?(Array)
+      @delivery_options[key] = value
+    end
     @valid = true
     @sms_action = method_name
     @sms_type = "#{self.class}.#{@sms_action}"


### PR DESCRIPTION
deep_dup not returning object references in a way that delayed_job could handle them correctly (failed during yaml conversion)

before fix:
![screen shot 2014-07-21 at 12 21 07](https://cloud.githubusercontent.com/assets/1729955/3642801/fd168f30-10c7-11e4-9fcf-c0e49e749f09.png)

after fix:
![screen shot 2014-07-21 at 12 20 58](https://cloud.githubusercontent.com/assets/1729955/3642803/06682fee-10c8-11e4-98e0-9c0df94abe05.png)
