### PR TITLE
Prepend smstrade sms with 00 - to avoid mixing up US numbers

### DIFF
--- a/lib/action_smser/base.rb
+++ b/lib/action_smser/base.rb
@@ -120,7 +120,7 @@ class ActionSmser::Base
     else
       [@to.to_s]
     end
-    array.collect{|number| number.gsub(/^(\+|0)/, "")}
+    array.collect{|number| number.gsub(/^(\+|0{1,2})/, "")}
   end
 
   def to_as_array

--- a/lib/action_smser/delivery_methods/smstrade.rb
+++ b/lib/action_smser/delivery_methods/smstrade.rb
@@ -29,7 +29,9 @@ module ActionSmser::DeliveryMethods
 
       sms.delivery_info = []
 
-      sms.to_numbers_array.each do |to|
+      # SmsTrade might confuse US numbers with German numbers if not prepended with 00 or +.
+      formatted_numbers = sms.to_numbers_array.map { |to| ["00", to].join }
+      formatted_numbers.each do |to|
         deliver_path = self.deliver_path(sms, to, options)
         response = self.deliver_http_request(sms, options, deliver_path)
 

--- a/test/unit/action_smser/base_test.rb
+++ b/test/unit/action_smser/base_test.rb
@@ -18,14 +18,14 @@ class ActionSmser::BaseTest < ActiveSupport::TestCase
   end
 
   setup do
-    @receivers = ["555123555", "123", "+358123555123"]
+    @receivers = ["555123555", "123", "+358123555123", "004915112341234", "04917332341111"]
     @sender = "555666"
     @body = "Body with ääkköset end"
     @sms = MockSms.basic_sms(@receivers, @sender, @body)
   end
 
   test "receivers should be joined by commas" do
-    assert_equal "555123555,123,358123555123", @sms.to_encoded
+    assert_equal "555123555,123,358123555123,4915112341234,4917332341111", @sms.to_encoded
   end
 
   test "should be ok with single receivers" do


### PR DESCRIPTION
We encountered a pretty nasty problem with SmsTrade. Their API works with both `+` or `00` prepended phone numbers but also without any prepending. However we realised that sending an SMS to US phone number like `17797xxxxx` which happens to also be a valid German number (without the country prefix) is actually sent to the German number - SmsTrade being a European / German business I guess.

We've contacted SmsTrade and they suggested we prepend every number with `00` to make it clear that it has a country prefix. Hence this PR :)

Thanks to @iblue for investigating this!

Oh and I wanted to write a test for this, but I couldn't get the Sqlite database correctly set up. Can you point me to what I'm doing wrong - I tried `bundle exec rake` after `RAILS_ENV bundle exec rake db:setup` and `RAILS_ENV=test bundle exec rake db:migrate` but I kept running into `ActiveRecord::PendingMigrationError` triggered here `action_smser/test/test_helper.rb:7`.