### PR TITLE
Lower the dependency bar to cover Rails 3.2

### DIFF
--- a/action_smser.gemspec
+++ b/action_smser.gemspec
@@ -17,13 +17,13 @@ Gem::Specification.new do |s|
   s.files = Dir["{app,config,db,lib}/**/*"] + ["MIT-LICENSE", "Rakefile", "README.md"]
   s.test_files = Dir["test/**/*"]
 
-  s.add_dependency "railties", ">= 4.1"
+  s.add_dependency "railties", ">= 3.2"
 
   s.add_development_dependency "mocha"
   #s.add_development_dependency "fakeweb"
 
   s.add_development_dependency "sqlite3"
-  s.add_development_dependency "rails", ">= 4.1"
+  s.add_development_dependency "rails", ">= 3.2"
   s.add_development_dependency "delayed_job"
 
 end


### PR DESCRIPTION
As you pointed out, the new dependency to `railties >= 4.1` prevented me from upgrading our Rails 3.2.19 app with the juicy SmsTrade fix :(
Would you consider this PR pretty please?

An update to a newer Rails version is hard to achieve for us at the moment..