### PR TITLE
Escape from parameter for Nexmo

### DIFF
--- a/lib/action_smser/delivery_methods/nexmo.rb
+++ b/lib/action_smser/delivery_methods/nexmo.rb
@@ -46,7 +46,7 @@ module ActionSmser::DeliveryMethods
     end
 
     def self.deliver_path(sms, to, options)
-      path = "/sms/json?username=#{options[:username]}&password=#{options[:password]}&ttl=#{sms.ttl_to_i*1000}&status-report-req=#{options[:status_report_req]}&from=#{sms.from_encoded}&to=#{to}&text=#{sms.body_escaped}"
+      path = "/sms/json?username=#{options[:username]}&password=#{options[:password]}&ttl=#{sms.ttl_to_i*1000}&status-report-req=#{options[:status_report_req]}&from=#{sms.from_escaped}&to=#{to}&text=#{sms.body_escaped}"
       path += "&type=#{options[:type]}" if options[:type]
       path
     end


### PR DESCRIPTION
Enables the use of special characters like æ, ø, å as sender.

We're using the following monkey patch now:

``` ruby
module ActionSmser::DeliveryMethods
  class Nexmo < SimpleHttp
    # @override
    def self.deliver_path(sms, to, options)
      path = "/sms/json?username=#{options[:username]}&password=#{options[:password]}&ttl=#{sms.ttl_to_i*1000}&status-report-req=#{options[:status_report_req]}&from=#{sms.from_escaped}&to=#{to}&text=#{sms.body_escaped}"
      path += "&type=#{options[:type]}" if options[:type]
      path
    end
  end
end
```
