### PR TITLE
Fix Time formatting deprecation warnings in Rails 7.0.0 upwards.

### DIFF
--- a/app/models/action_smser/delivery_report.rb
+++ b/app/models/action_smser/delivery_report.rb
@@ -27,7 +27,7 @@ if defined?(ActiveRecord)
       def status=(stat, skip_log = false)
         self[:status] = stat
         self.status_updated_at = Time.now
-        add_log("#{Time.now.to_s(:db)}: #{stat}") unless skip_log
+        add_log("#{Time.now.to_fs(:db)}: #{stat}") unless skip_log
       end
 
       def add_log(str)

--- a/app/views/action_smser/delivery_reports/index.html.erb
+++ b/app/views/action_smser/delivery_reports/index.html.erb
@@ -39,7 +39,7 @@
 
 
 <h1>Delivery Reports Summary for
-  (<span style="font-size: smaller"><%= "#{time_span.first.to_s(:db)} => #{time_span.last.to_s(:db)}" %></span>)
+  (<span style="font-size: smaller"><%= "#{time_span.first.to_fs(:db)} => #{time_span.last.to_fs(:db)}" %></span>)
   <%= "for #{params[:gateway]}" unless params[:gateway].blank? %>
 </h1>
 


### PR DESCRIPTION
Use time.to_fs instead of time.to_s, see https://apidock.com/rails/v7.0.0/Time/to_s

When upgrading our app to Rails 7 we get a bunch of deprecation warnings when running tests that use the `action_smser` gem.

`DEPRECATION WARNING: Time#to_s(:db) is deprecated. Please use Time#to_fs(:db) instead.`

PS: Thanks for your nice work on it. 