### PR TITLE
Fix time formatting rails 6.x regression

### DIFF
--- a/app/models/action_smser/delivery_report.rb
+++ b/app/models/action_smser/delivery_report.rb
@@ -27,7 +27,7 @@ if defined?(ActiveRecord)
       def status=(stat, skip_log = false)
         self[:status] = stat
         self.status_updated_at = Time.now
-        add_log("#{Time.now.to_fs(:db)}: #{stat}") unless skip_log
+        add_log("#{Time.now.to_formatted_s(:db)}: #{stat}") unless skip_log
       end
 
       def add_log(str)

--- a/app/views/action_smser/delivery_reports/index.html.erb
+++ b/app/views/action_smser/delivery_reports/index.html.erb
@@ -39,7 +39,7 @@
 
 
 <h1>Delivery Reports Summary for
-  (<span style="font-size: smaller"><%= "#{time_span.first.to_fs(:db)} => #{time_span.last.to_fs(:db)}" %></span>)
+  (<span style="font-size: smaller"><%= "#{time_span.first.to_formatted_s(:db)} => #{time_span.last.to_formatted_s(:db)}" %></span>)
   <%= "for #{params[:gateway]}" unless params[:gateway].blank? %>
 </h1>
 


### PR DESCRIPTION
I inadvertently introduced a regression bug in Rails 6 for the gem with my [PR #15](https://github.com/holli/action_smser/pull/15). My apologies, I had glanced over the docs too quickly. Anyhow, by using the non-aliased time formatting version it also works with Rails 6.x, see https://apidock.com/rails/v3.0.0/Time/to_formatted_s.

Using `time.to_fs` on Rails 6.x leads to the error:
```
NoMethodError: undefined method `to_fs' for 2024-04-26 05:29:41.420230265 +0000:Time
        add_log("#{Time.now.to_fs(:db)}: #{stat}") unless skip_log
```

Note: Not sure about the overall support for Rails 6 though ... 
- in the Changelog you state that support for it is dropped with version 3.3.0
- but the gemspec permits it [s.add_dependency "railties", ">= 6"](https://github.com/holli/action_smser/blob/master/action_smser.gemspec)

FYI: Some unrelated gem tests fail when I run it with `RAILS_VERSION=6.1`, but I guess you are aware of that.